### PR TITLE
Update for 2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,12 @@ requirements:
   host:
     - python
     - tensorflow-base {{ tensorflow }}
-    - typing {{ typing }}  # [py>=38]
-    - typing_extensions {{ typing }}  # [py<38]
+    - typing_extensions {{ typing_extensions }}  # [py<38]
     - python-flatbuffers {{ flatbuffers }}
   run:
     - python
     - tensorflow-base {{ tensorflow }}
-    - typing {{ typing }}  # [py>=38]
-    - typing_extensions {{ typing }}  # [py<38]
+    - typing_extensions {{ typing_extensions }}  # [py<38]
     - python-flatbuffers {{ flatbuffers }}
     
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,8 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: 2.4.0
+#  version: {{ version }}
 
 source:
   git_url: https://github.com/tensorflow/estimator.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,15 +21,15 @@ requirements:
   host:
     - python
     - tensorflow-base {{ tensorflow }}
-    - typing               # [py>=38]
-    - typing_extensions    # [py<38]
-    - python-flatbuffers
+    - typing {{ typing }}  # [py>=38]
+    - typing_extensions  # [py<38]
+    - python-flatbuffers {{ flatbuffers }}
   run:
     - python
     - tensorflow-base {{ tensorflow }}
-    - typing               # [py>=38]
-    - typing_extensions    # [py<38
-    - python-flatbuffers
+    - typing {{ typing }  # [py>=38]
+    - typing_extensions  # [py<38]
+    - python-flatbuffers {{ flatuffers }}
     
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   git_url: https://github.com/tensorflow/estimator.git
-  git_rev: v{{ version }}-rc0
+  git_rev: v{{ version }}
  
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,12 +21,14 @@ requirements:
   host:
     - python
     - tensorflow-base {{ tensorflow }}
-    - typing_extensions
+    - typing               # [py>=38]
+    - typing_extensions    # [py<38]
     - python-flatbuffers
   run:
     - python
     - tensorflow-base {{ tensorflow }}
-    - typing_extensions
+    - typing               # [py>=38]
+    - typing_extensions    # [py<38
     - python-flatbuffers
     
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,13 +22,13 @@ requirements:
     - python
     - tensorflow-base {{ tensorflow }}
     - typing {{ typing }}  # [py>=38]
-    - typing_extensions  # [py<38]
+    - typing_extensions {{ typing }}  # [py<38]
     - python-flatbuffers {{ flatbuffers }}
   run:
     - python
     - tensorflow-base {{ tensorflow }}
-    - typing {{ typing }  # [py>=38]
-    - typing_extensions  # [py<38]
+    - typing {{ typing }}  # [py>=38]
+    - typing_extensions {{ typing }}  # [py<38]
     - python-flatbuffers {{ flatuffers }}
     
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # tensorflow-estimator meta data file
 {% set name = "tensorflow-estimator" %}
-{% set version = "2.3.0" %}
+{% set version = "2.4" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   git_url: https://github.com/tensorflow/estimator.git
-  git_rev: v{{ version }}
+  git_rev: r{{ version }}
  
 build:
   number: 1
@@ -21,9 +21,13 @@ requirements:
   host:
     - python
     - tensorflow-base {{ tensorflow }}
+    - typing_extensions
+    - python-flatbuffers
   run:
     - python
     - tensorflow-base {{ tensorflow }}
+    - typing_extensions
+    - python-flatbuffers
     
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,14 @@
 # tensorflow-estimator meta data file
 {% set name = "tensorflow-estimator" %}
-{% set version = "2.4.0-rc0" %}
+{% set version = "2.4.0" %}
 
 package:
   name: {{ name }}
-  version: 2.4.0
-#  version: {{ version }}
+  version: {{ version }}
 
 source:
   git_url: https://github.com/tensorflow/estimator.git
-  git_rev: r{{ version }}
+  git_rev: v{{ version }}-rc0
  
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # tensorflow-estimator meta data file
 {% set name = "tensorflow-estimator" %}
-{% set version = "2.4" %}
+{% set version = "2.4.0-rc0" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - tensorflow-base {{ tensorflow }}
     - typing {{ typing }}  # [py>=38]
     - typing_extensions {{ typing }}  # [py<38]
-    - python-flatbuffers {{ flatuffers }}
+    - python-flatbuffers {{ flatbuffers }}
     
 test:
   imports:


### PR DESCRIPTION
Draft to update estimator to 2.4.

Python-flatbuffers needed because: https://github.com/tensorflow/tensorflow/commit/7d94d03f7a82bcd9e4d86f2cde3e5b5355d01520

`typing` and/or `typing_extensions` are needed because of: https://github.com/tensorflow/tensorflow/commit/40a314cab8d6c7afbc62456433a033c1cab8d74f