### PR TITLE
Fixed build as libtensorflow_framework is now part of libtensorflow p…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   git_rev: v{{ version }}
  
 build:
-  number: 1
+  number: 2
   string: py_{{ PKG_BUILDNUM }}
   noarch: python
 
@@ -22,11 +22,13 @@ requirements:
   host:
     - python
     - tensorflow-base {{ tensorflow }}
+    - libtensorflow {{ tensorflow }}
     - typing_extensions {{ typing_extensions }}
     - python-flatbuffers {{ flatbuffers }}
   run:
     - python
     - tensorflow-base {{ tensorflow }}
+    - libtensorflow {{ tensorflow }}
     - typing_extensions {{ typing_extensions }}
     - python-flatbuffers {{ flatbuffers }}
     


### PR DESCRIPTION
…ackage

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

TF Estimator needs libtensorflow_framework.so at build time and runtime. Under this PR https://github.com/open-ce/tensorflow-feedstock/pull/44, I moved libtensorflow_framework.so into libtensorflow package and hence I'd to add libtensorflow in the dependencies of TF Estimator.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
